### PR TITLE
Updates maven doc for S3 credentials and plugin repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ your project, so you should take them from the environment using
 
      <!-- to consume artifacts from a private bucket -->
 
+     <pluginRepositories>
+       <pluginRepository>
+         <id>clojars.org</id>
+         <name>Clojars Repository</name>
+         <url>http://clojars.org/repo</url>
+       </pluginRepository>
+     </pluginRepositories>
+
      <repositories>
         <repository>
             <id>someId</id>
@@ -137,6 +145,7 @@ your project, so you should take them from the environment using
             <!-- you can actually put the key and secret in here, I like to get them from the env -->
             <id>someId</id>
             <username>${env.AWS_ACCESS_KEY}</username>
+            <privateKey>${user.home}/.ssh/id_rsa</privateKey>
             <passphrase>${env.AWS_SECRET_KEY}</passphrase>
         </server>
     </servers>


### PR DESCRIPTION
#### Environment

```
Apache Maven 3.2.1 (ea8b2b07643dbb1b84b6d16e1f08391b666bc1e9; 2014-02-14T23:07:52+05:30)
Maven home: /usr/share/maven3
Java version: 1.8.0_40, vendor: Oracle Corporation
Java home: /usr/lib/jvm/jdk1.8.0_40/jre
Default locale: en_IN, platform encoding: UTF-8
OS name: "linux", version: "3.5.0-030500-generic", arch: "amd64", family: "unix"
```

#### Fixes
Since the extension ``s3-wagon-private`` is available only with Clojars. We need to add a ``pluginRepository`` for maven to pick it up-

```xml
<pluginRepositories>
  <pluginRepository>
    <id>clojars.org</id>
    <name>Clojars Repository</name>
    <url>http://clojars.org/repo</url>
  </pluginRepository>
</pluginRepositories>
```
The S3 credentials didn't work for me until I added the ``<privateKey>${user.home}/.ssh/id_rsa</privateKey>`` explicitly. Maven expects it to be there. This blog highlights the issue- http://liviutudor.com/2014/08/27/fixing-aws-maven-issue-with-access-denied/