### PR TITLE
Fix ClassNotFound when running from maven

### DIFF
--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -3,8 +3,7 @@
         <component>
             <role>org.apache.maven.wagon.Wagon</role>
             <role-hint>s3p</role-hint>
-            <implementation>org.springframework.aws.maven.PrivateS3Wagon</implementation>
-            <!-- <implementation>org.springframework.aws.maven.SimpleStorageServiceWagon</implementation> -->
+            <implementation>org.springframework.build.aws.maven.PrivateS3Wagon</implementation>
             <instantiation-strategy>per-lookup</instantiation-strategy>
         </component>
     </components>


### PR DESCRIPTION
I was seeing an error trying to release from maven with "mvn release:perform" on maven versions 3.0.5, 3.2.1 and 3.3.9.

The problem was a Class Not Found exception on `org.springframework.aws.maven.PrivateS3Wagon`, which makes sense since the package has been renamed to `org.springframework.build.aws.maven.` (note the **build**).

This change updates the class reference in the plexus configuration xml to point to the current fully qualified classname. I also took the liberty of removing a commented out line to clean up the file.

There is another plexus configuration file in `res/META-INF/plexus/components.xml` with a different implementation of the wagon specified. I assumed this was a relic of an earlier implementation and not used, although I'm not sure and I don't know if that's correct. So I've left it as it is.

---

The full maven stack track I was seeing:

```
[INFO] may 26, 2016 9:24:19 PM org.sonatype.guice.bean.reflect.Logs$JULSink warn
[INFO] ADVERTENCIA: Error injecting: org.springframework.aws.maven.PrivateS3Wagon
[INFO] java.lang.TypeNotPresentException: Type org.springframework.aws.maven.PrivateS3Wagon not present
[INFO] 	at org.sonatype.guice.bean.reflect.URLClassSpace.loadClass(URLClassSpace.java:105)
[INFO] 	at org.sonatype.guice.bean.reflect.NamedClass.load(NamedClass.java:45)
[INFO] 	at org.sonatype.guice.bean.reflect.AbstractDeferredClass.get(AbstractDeferredClass.java:45)
[INFO] 	at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:84)
[INFO] 	at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:52)
[INFO] 	at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:70)
[INFO] 	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
[INFO] 	at org.sonatype.guice.plexus.lifecycles.PlexusLifecycleManager.onProvision(PlexusLifecycleManager.java:138)
[INFO] 	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:108)
[INFO] 	at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
[INFO] 	at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:68)
[INFO] 	at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:45)
[INFO] 	at com.google.inject.internal.InjectorImpl$3$1.call(InjectorImpl.java:965)
[INFO] 	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1011)
[INFO] 	at com.google.inject.internal.InjectorImpl$3.get(InjectorImpl.java:961)
[INFO] 	at com.google.inject.Scopes$1$1.get(Scopes.java:59)
[INFO] 	at org.sonatype.guice.bean.locators.LazyBeanEntry.getValue(LazyBeanEntry.java:83)
[INFO] 	at org.sonatype.guice.plexus.locators.LazyPlexusBean.getValue(LazyPlexusBean.java:49)
[INFO] 	at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:253)
[INFO] 	at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:245)
[INFO] 	at org.sonatype.aether.connector.wagon.PlexusWagonProvider.lookup(PlexusWagonProvider.java:32)
[INFO] 	at org.sonatype.aether.connector.wagon.WagonRepositoryConnector.lookupWagon(WagonRepositoryConnector.java:282)
[INFO] 	at org.sonatype.aether.connector.wagon.WagonRepositoryConnector.<init>(WagonRepositoryConnector.java:154)
[INFO] 	at org.sonatype.aether.connector.wagon.WagonRepositoryConnectorFactory.newInstance(WagonRepositoryConnectorFactory.java:142)
[INFO] 	at org.sonatype.aether.impl.internal.DefaultRemoteRepositoryManager.getRepositoryConnector(DefaultRemoteRepositoryManager.java:346)
[INFO] 	at org.sonatype.aether.impl.internal.DefaultDeployer.deploy(DefaultDeployer.java:231)
[INFO] 	at org.sonatype.aether.impl.internal.DefaultDeployer.deploy(DefaultDeployer.java:211)
[INFO] 	at org.sonatype.aether.impl.internal.DefaultRepositorySystem.deploy(DefaultRepositorySystem.java:443)
[INFO] 	at org.apache.maven.artifact.deployer.DefaultArtifactDeployer.deploy(DefaultArtifactDeployer.java:137)
[INFO] 	at org.apache.maven.plugin.deploy.AbstractDeployMojo.deploy(AbstractDeployMojo.java:171)
[INFO] 	at org.apache.maven.plugin.deploy.DeployMojo.deployProject(DeployMojo.java:250)
[INFO] 	at org.apache.maven.plugin.deploy.DeployMojo.execute(DeployMojo.java:169)
[INFO] 	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
[INFO] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
[INFO] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
[INFO] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
[INFO] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
[INFO] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
[INFO] 	at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
[INFO] 	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
[INFO] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:320)
[INFO] 	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
[INFO] 	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
[INFO] 	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
[INFO] 	at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
[INFO] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[INFO] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[INFO] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[INFO] 	at java.lang.reflect.Method.invoke(Method.java:483)
[INFO] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
[INFO] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
[INFO] 	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
[INFO] 	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
[INFO] Caused by: java.lang.ClassNotFoundException: org.springframework.aws.maven.PrivateS3Wagon
[INFO] 	at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
[INFO] 	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:244)
[INFO] 	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:230)
[INFO] 	at org.sonatype.guice.bean.reflect.URLClassSpace.loadClass(URLClassSpace.java:101)
```